### PR TITLE
Delete status message

### DIFF
--- a/src/congress/game.py
+++ b/src/congress/game.py
@@ -29,7 +29,8 @@ class Game(GameBase):
             Logger.game("Game", "Congress bot mode initialized")
 
         if self.is_network_game:
-            self.update_status_message("Waiting for another player...")
+            if self.render:
+                self.render.edit_info_label("Waiting for another player...")
 
     def on_network_action(self, action_data):
         """
@@ -101,10 +102,12 @@ class Game(GameBase):
         # met à jour le message de statut en fonction du tour
         if self.is_network_game:
             if self.is_my_turn: 
-                self.update_status_message(f"Your turn (Player {self.player_number})", "green")
+                if self.render:
+                    self.render.edit_info_label(f"Your turn (Player {self.player_number})")
             else:
                 other_player_number = 1 if self.round_turn == 0 else 2
-                self.update_status_message(f"Player {other_player_number}'s turn", "orange")
+                if self.render:
+                    self.render.edit_info_label(f"Player {other_player_number}'s turn")
         else:
             self.render.edit_info_label(f"Player {self.round_turn + 1}'s turn")
             

--- a/src/isolation/game.py
+++ b/src/isolation/game.py
@@ -28,7 +28,8 @@ class Game(GameBase):
             self.render.edit_info_label("Player 1's turn - Place your tower")
         
         if self.is_network_game:
-            self.update_status_message("Waiting for another player...")
+            if self.render:
+                self.render.edit_info_label("Waiting for another player...")
 
     def on_network_action(self, action_data):
         """
@@ -74,10 +75,12 @@ class Game(GameBase):
         # met à jour le message de statut en fonction du tour
         if self.is_network_game:
             if self.is_my_turn: 
-                self.update_status_message(f"Your turn (Player {self.player_number}) - Place tower", "green")
+                if self.render:
+                    self.render.edit_info_label(f"Your turn (Player {self.player_number}) - Place tower")
             else:
                 other_player_number = 1 if self.round_turn == 0 else 2
-                self.update_status_message(f"Player {other_player_number}'s turn - Place tower", "orange")
+                if self.render:
+                    self.render.edit_info_label(f"Player {other_player_number}'s turn - Place tower")
         else:
              self.render.edit_info_label(f"Player {self.round_turn + 1}'s turn - Place your tower")
             

--- a/src/katerenga/game.py
+++ b/src/katerenga/game.py
@@ -37,7 +37,8 @@ class Game(GameBase):
             Logger.game("Game", "Katerenga bot mode initialized")
 
         if self.is_network_game:
-            self.update_status_message("Waiting for another player...")
+            if self.render:
+                self.render.edit_info_label("Waiting for another player...")
 
     def on_network_action(self, action_data):
         """
@@ -97,10 +98,12 @@ class Game(GameBase):
         # met à jour le message de statut en fonction du tour
         if self.is_network_game:
             if self.is_my_turn: # is_my_turn doit avoir été mis à jour par les gestionnaires de GameBase
-                self.update_status_message(f"Your turn (Player {self.player_number})", "green")
+                if self.render:
+                    self.render.edit_info_label(f"Your turn (Player {self.player_number})")
             else:
                 other_player = 1 if self.player_number == 2 else 2  # numéro de joueur opposé
-                self.update_status_message(f"Player {other_player}'s turn", "orange")
+                if self.render:
+                    self.render.edit_info_label(f"Player {other_player}'s turn")
         else:
             # fallback pour le contexte non réseau, bien que cette fonction principalement gère le réseau
             self.render.edit_info_label(f"Player {self.round_turn + 1}'s turn")


### PR DESCRIPTION
On n'utilise plus le status message du render mais désormais le info bar.
Permet d'éviter des problèmes d'affichages de messages sur le réseau notamment. 
fait suite à https://github.com/simonpotel/Ludoria/issues/94