### PR TITLE
fix regle katarenga

### DIFF
--- a/src/katerenga/bot.py
+++ b/src/katerenga/bot.py
@@ -154,6 +154,11 @@ class KaterengaBot:
         end_row, end_col = end
         bot_camps = [(r, c) for r, c in self.game.camps if r == 0] # Camps du bot
 
+        # valeur très élevée pour les mouvements vers un camp depuis la dernière ligne
+        if start_row == 9 and (end_row, end_col) in bot_camps:
+            if self.game.board.board[end_row][end_col][0] is None or self.game.board.board[end_row][end_col][0] != 1:
+                return 10  # priorité maximale pour rejoindre un camp depuis la dernière ligne
+
         # valeur élevée pour les mouvements vers un camp libre
         if self.is_camp_move(end_row, end_col, bot_camps):
              if self.game.board.board[end_row][end_col][0] is None or self.game.board.board[end_row][end_col][0] != 1:

--- a/src/katerenga/game.py
+++ b/src/katerenga/game.py
@@ -231,8 +231,12 @@ class Game(GameBase):
             # détermine l'index correct du joueur à vérifier
             player_index_to_select = self.player_number - 1 if self.is_network_game else self.round_turn
             
+            # détermine les camps adverses en fonction du joueur pour la vérification de sélection
+            opponent_camps = [(9, 0), (9, 9)] if player_index_to_select == 0 else [(0, 0), (0, 9)]
+
             # sélection d'une pièce du joueur dont c'est le tour (ou du joueur local en réseau)
-            if cell[0] is not None and cell[0] == player_index_to_select:
+            # ajout de la condition pour vérifier si la pièce n'est PAS dans un camp adverse
+            if cell[0] is not None and cell[0] == player_index_to_select and (row, col) not in opponent_camps:
                 # vérification supplémentaire pour le mode réseau : s'assurer que c'est bien le tour de ce joueur
                 if self.is_network_game and not self.is_my_turn:
                     self.render.edit_info_label(f"Waiting for Player {2 if self.player_number == 1 else 1}")
@@ -241,6 +245,10 @@ class Game(GameBase):
                 self.selected_piece = (row, col)
                 self.render.edit_info_label("Select destination")
                 self.render.needs_render = True
+                return True
+            elif cell[0] is not None and cell[0] == player_index_to_select and (row, col) in opponent_camps:
+                # clic sur une pièce du joueur mais dans un camp adverse - ne pas sélectionner
+                self.render.edit_info_label("Cannot move piece from opponent's camp")
                 return True
             elif cell[0] is not None:
                 # clic sur une pièce adverse ou une case vide

--- a/src/moves.py
+++ b/src/moves.py
@@ -16,10 +16,53 @@ def available_move(board, iRow, iCol, dRow, dCol):
     initial = board[iRow][iCol]
     destination = board[dRow][dCol]
     
+    player = initial[0]
+    camps = [(0, 0), (0, 9), (9, 0), (9, 9)]
+
+    # verifie si la pièce de départ est dans un camp adverse
+    # si la pièce est dans un camp adverse, elle ne peut pas se déplacer
+    if (iRow, iCol) in camps:
+        # determine le joueur du camp
+        camp_player = None
+        if (iRow, iCol) == (0, 0) or (iRow, iCol) == (0, 9):
+            camp_player = 1  # Camps du haut pour le joueur 1
+        elif (iRow, iCol) == (9, 0) or (iRow, iCol) == (9, 9):
+            camp_player = 0  # Camps du bas pour le joueur 0
+            
+        # si le camp appartient au joueur adverse de la pièce, le mouvement est invalide
+        if camp_player is not None and camp_player != player:
+             Logger.warning("Moves", "Invalid move: cannot move pieces out of opponent camps")
+             return False
+
     if destination[0] is not None and destination[0] == initial[0]:
         Logger.warning("Moves", f"Invalid move: destination cell ({dRow},{dCol}) is occupied by your own piece")
         return False
-        
+
+    # vérification spéciale pour le déplacement vers un camp adverse
+    finish_line = 9 if player == 0 else 0  # ligne d'arrivée pour le joueur
+    
+    # si la destination est un camp, on vérifie uniquement la règle des deux dernières lignes
+    if (dRow, dCol) in camps:
+        # verifie si la pièce est sur la dernière ou l'avant-dernière ligne
+        is_on_allowed_line = False
+        if player == 0:
+            if iRow == finish_line or iRow == finish_line - 1:
+                is_on_allowed_line = True
+        else:
+            if iRow == finish_line or iRow == finish_line + 1:
+                is_on_allowed_line = True
+
+        if not is_on_allowed_line:
+            Logger.warning("Moves", "Invalid move: can only access opponent camps from the last two lines")
+            return False
+
+        if destination[0] is not None and destination[0] == player:
+            Logger.warning("Moves", "Invalid move: camp is occupied by your own piece")
+            return False
+        Logger.success("Moves", "Valid move to opponent camp from allowed lines")
+        return True
+
+    # si la destination n'est pas un camp, on vérifie les règles de mouvement normales
     match initial[1]:
         case 0:
             if iRow != dRow and iCol != dCol:
@@ -112,7 +155,6 @@ def available_move(board, iRow, iCol, dRow, dCol):
                 Logger.success("Moves", "Valid Bishop move")
                 return True
             
-            # parcourir encore une fois pour vérifier qu'on ne dépasse pas de case jaune
             row, col = iRow + step_row, iCol + step_col
             while row != dRow and col != dCol:
                 if board[row][col][1] == 3:
@@ -125,5 +167,5 @@ def available_move(board, iRow, iCol, dRow, dCol):
             return True
             
     Logger.error("Moves", f"Invalid cell color: {initial[1]}")
-    return False  
+    return False
                 


### PR DESCRIPTION
This pull request introduces several updates to improve the gameplay logic in the `Katerenga` project, focusing on movement rules and restrictions related to camps. The changes ensure that player pieces cannot move out of opponent camps, enforce stricter conditions for entering camps, and provide clearer in-game feedback for invalid moves.

### Movement rules and restrictions:

* **Prevent moving pieces out of opponent camps**: Added logic in `available_move` to disallow movement of pieces from opponent camps, with appropriate logging for invalid attempts. (`src/moves.py`, [src/moves.pyR19-R65](diffhunk://#diff-a530777910a6adb677fa1dcbd89cf0a7a6ae923281ceffbf8558dd843105505dR19-R65))

* **Restrict access to opponent camps**: Enforced rules in `available_move` to allow entry into opponent camps only from the last two rows, and only if the camp is unoccupied or not owned by the player. (`src/moves.py`, [src/moves.pyR19-R65](diffhunk://#diff-a530777910a6adb677fa1dcbd89cf0a7a6ae923281ceffbf8558dd843105505dR19-R65))

### In-game feedback improvements:

* **Disallow selecting pieces in opponent camps**: Updated `on_click` to prevent players from selecting their own pieces located in opponent camps, with a new message displayed to the player. (`src/katerenga/game.py`, [[1]](diffhunk://#diff-1ebacb3147e013fbf6e1da1f86f0d609fb7cb681abfe0d303cf12d307070f973R234-R239) [[2]](diffhunk://#diff-1ebacb3147e013fbf6e1da1f86f0d609fb7cb681abfe0d303cf12d307070f973R249-R252)

### Bot prioritization updates:

* **Prioritize bot moves to camps**: Adjusted `_simulate_move_and_count_captures` to assign a very high priority to bot moves targeting camps from the last row. (`src/katerenga/bot.py`, [src/katerenga/bot.pyR157-R161](diffhunk://#diff-30bc774d38e89fd23ee725c74fb9b9b59b25822f46a300bc2557ce3414c164cfR157-R161))